### PR TITLE
favour https over ssh for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "assets/cf-redis-example-app"]
 	path = assets/cf-redis-example-app
-	url = git@github.com:pivotal-cf/cf-redis-example-app
+	url = https://github.com/pivotal-cf/cf-redis-example-app


### PR DESCRIPTION
This breaks use of cf-redis-release for non-Pivots everywhere, which is more of a concern now the repo is OSS, rather than being private and proprietary as was the case when my dear friends Tiago and Will opted for SSH.