### PR TITLE
SSH breaks development of cf-redis-release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "assets/cf-redis-example-app"]
 	path = assets/cf-redis-example-app
-	url = git@github.com:pivotal-cf/cf-redis-example-app
+	url = https://github.com/pivotal-cf/cf-redis-example-app


### PR DESCRIPTION
`git submodule update` fails with SSH. Going to HTTP allows access seamlessly.