### PR TITLE
Ensure that CF security groups are cleaned up

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -159,6 +159,10 @@ var _ = Describe("Redis Service", func() {
 					testCF.UnbindService(appName, serviceInstanceName),
 				),
 				reporter.NewStep(
+					fmt.Sprintf("Delete security group '%s'", securityGroupName),
+					testCF.DeleteSecurityGroup(securityGroupName),
+				),
+				reporter.NewStep(
 					fmt.Sprintf("Delete the service key %s for the %q plan instance", serviceKeyName, planName),
 					testCF.DeleteServiceKey(serviceInstanceName, serviceKeyName),
 				),
@@ -256,6 +260,10 @@ var _ = Describe("Redis Service", func() {
 						testCF.UnbindService(appName, serviceInstanceName),
 					),
 					reporter.NewStep(
+						fmt.Sprintf("Delete security group '%s'", securityGroupName),
+						testCF.DeleteSecurityGroup(securityGroupName),
+					),
+					reporter.NewStep(
 						fmt.Sprintf("Delete the service key %s for the %q plan instance", serviceKeyName, planName),
 						testCF.DeleteServiceKey(serviceInstanceName, serviceKeyName),
 					),
@@ -292,4 +300,3 @@ var _ = Describe("Redis Service", func() {
 func randomName() string {
 	return uuid.NewRandom().String()
 }
-


### PR DESCRIPTION
Hi cf-redis-smoke-tests team,

The smoke tests have the functionality to delete the security group but weren't actually _using_ that functionality. This change ensures that the security group is actually deleted after the tests run.

I have tested this against a running redis deployment and verified that the tests pass, and that the security group gets cleaned up as expected

We found out about this issue when our prometheus cf_exporter scrape started taking a long time due to security group leaks from these tests... 3 minutes to scrape 3000 security groups :)

kind regards,

Pete

