### PR TITLE
REDVM-389: Updates security group test case to include more than one hosts when HA is enabled

### DIFF
--- a/cf/cf.go
+++ b/cf/cf.go
@@ -229,7 +229,10 @@ func (cf *CF) CreateAndBindSecurityGroup(securityGroup, serviceName, org, space 
 		sgs := make([]SecurityGroup, 0)
 
 		for _, destination := range destinations {
-			sgs = append(sgs, SecurityGroup{Protocol: "tcp", Destination: destination, Ports: ports})
+			dest := strings.TrimSpace(destination)
+			if dest != "" {
+				sgs = append(sgs, SecurityGroup{Protocol: "tcp", Destination: dest, Ports: ports})
+			}
 		}
 
 		err = json.NewEncoder(sgFile).Encode(sgs)


### PR DESCRIPTION
changes:
- Updates test cases for including more than one host found with `dig` command

todos:
- add support for sentinel port (both tls and non-tls) - will be included in story REDVM-407

please review and add comments/suggestions for the changes