### PR TITLE
REDVM-409: adds ha smoke test cases

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -96,3 +96,12 @@ func (app *App) ReadTLSAssert(tlsVersion, key, expectedValue string) func() {
 		)
 	}
 }
+
+func (app *App) Read(key string) []byte {
+	curlFn := func() *gexec.Session {
+		fmt.Printf("\nGetting from url: %s\n", app.keyURI(key))
+		return helpers.CurlSkipSSL(true, app.keyURI(key))
+	}
+
+	return retry.Session(curlFn).FetchOutput()
+}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -168,6 +168,17 @@ func MatchesOutput(regex *regexp.Regexp) Condition {
 	}
 }
 
+func (rc *retryCheck) FetchOutput() []byte {
+	time.Sleep(rc.backoff(0))
+	session := rc.sessionProvider().Wait(rc.sessionTimeout)
+
+	if session.ExitCode() != 0 {
+		return session.Err.Contents()
+	}
+
+	return session.Out.Contents()
+}
+
 func MatchesErrorOutput(regex *regexp.Regexp) Condition {
 	return func(session *gexec.Session) bool {
 		return regex.Match(session.Err.Contents())

--- a/service/service_ha_test.go
+++ b/service/service_ha_test.go
@@ -1,0 +1,295 @@
+package service_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pivotal-cf/cf-redis-smoke-tests/redis"
+	"github.com/pivotal-cf/cf-redis-smoke-tests/service/reporter"
+
+	smokeTestCF "github.com/pivotal-cf/cf-redis-smoke-tests/cf"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/cf-redis-smoke-tests/service/utils"
+)
+
+var _ = Describe("Redis HA", Label("ha"), func() {
+	var (
+		testCF = smokeTestCF.CF{
+			ShortTimeout: time.Minute * 6,
+			LongTimeout:  time.Minute * 15,
+			RetryBackoff: redisConfig.Retry.Backoff(),
+			MaxRetries:   redisConfig.Retry.MaxRetries(),
+		}
+
+		retryInterval = time.Second
+
+		appPath             = "../assets/cf-redis-example-app"
+		serviceInstanceName string
+		appName             string
+		planName            string
+		securityGroupName   string
+		serviceKeyName      string
+		serviceKey          smokeTestCF.Credentials
+	)
+
+	Context("service instance", func() {
+		var skip bool
+
+		BeforeEach(func() {
+			appName = randomName()
+			serviceInstanceName = randomName()
+			securityGroupName = randomName()
+			serviceKeyName = randomName()
+
+			cfTestConfig := redisConfig.Config
+
+			pushArgs := []string{
+				"-m", "256M",
+				"-p", appPath,
+				"-b", "ruby_buildpack",
+				"--no-start",
+			}
+
+			var loginStep *reporter.Step
+			if cfTestConfig.AdminClient != "" && cfTestConfig.AdminClientSecret != "" {
+				loginStep = reporter.NewStep(
+					"Log in as admin client",
+					testCF.AuthClient(cfTestConfig.AdminClient, cfTestConfig.AdminClientSecret),
+				)
+			} else {
+				loginStep = reporter.NewStep(
+					"Log in as admin user",
+					testCF.Auth(cfTestConfig.AdminUser, cfTestConfig.AdminPassword),
+				)
+			}
+
+			specSteps := []*reporter.Step{
+				reporter.NewStep(
+					"Connect to CloudFoundry",
+					testCF.API(cfTestConfig.ApiEndpoint, cfTestConfig.SkipSSLValidation),
+				),
+				loginStep,
+				reporter.NewStep(
+					fmt.Sprintf("Target '%s' org and '%s' space", wfh.GetOrganizationName(), wfh.TestSpace.SpaceName()),
+					testCF.TargetOrgAndSpace(wfh.GetOrganizationName(), wfh.TestSpace.SpaceName()),
+				),
+				reporter.NewStep(
+					"Push the redis sample app to Cloud Foundry",
+					testCF.Push(appName, pushArgs...),
+				),
+			}
+
+			smokeTestReporter.ClearSpecSteps()
+			smokeTestReporter.RegisterSpecSteps(specSteps)
+			performSteps(specSteps)
+
+			uri := fmt.Sprintf("https://%s.%s", appName, redisConfig.Config.AppsDomain)
+
+			if redisConfig.UseHttpApp {
+				uri = fmt.Sprintf("http://%s.%s", appName, redisConfig.Config.AppsDomain)
+			}
+
+			app := redis.NewApp(uri, testCF.ShortTimeout, retryInterval)
+
+			enableServiceAccessStep := reporter.NewStep(
+				fmt.Sprintf("Enable service plan access for '%s' org", wfh.GetOrganizationName()),
+				testCF.EnableServiceAccessForPlan(wfh.GetOrganizationName(), redisConfig.ServiceName, planName),
+			)
+			serviceCreateStep := reporter.NewStep(
+				fmt.Sprintf("Create a '%s' plan instance of Redis\n    Please refer to http://docs.pivotal.io/redis/smoke-tests.html for more help on diagnosing this issue", planName),
+				testCF.CreateService(redisConfig.ServiceName, planName, serviceInstanceName, &skip),
+			)
+
+			smokeTestReporter.RegisterSpecSteps([]*reporter.Step{enableServiceAccessStep, serviceCreateStep})
+			enableServiceAccessStep.Perform()
+			serviceCreateStep.Perform()
+
+			serviceCreateStep.Description = fmt.Sprintf("Create a '%s' plan instance of Redis", planName)
+
+			specSteps = []*reporter.Step{
+				reporter.NewStep(
+					fmt.Sprintf("Bind the redis sample app '%s' to the '%s' plan instance '%s' of Redis", appName, planName, serviceInstanceName),
+					testCF.BindService(appName, serviceInstanceName),
+				),
+				reporter.NewStep(
+					fmt.Sprintf("Create service key for the '%s' plan instance '%s' of Redis", planName, serviceInstanceName),
+					testCF.CreateServiceKey(serviceInstanceName, serviceKeyName),
+				),
+				reporter.NewStep(
+					"Read the Service Key",
+					testCF.GetServiceKey(serviceInstanceName, &serviceKey),
+				),
+				reporter.NewStep(
+					fmt.Sprintf("Create and bind security group '%s' for running smoke tests", securityGroupName),
+					testCF.CreateAndBindSecurityGroup(securityGroupName, serviceInstanceName, wfh.GetOrganizationName(), wfh.TestSpace.SpaceName()),
+				),
+				reporter.NewStep(
+					"Start the app",
+					testCF.Start(appName),
+				),
+				reporter.NewStep(
+					"Verify that the app is responding",
+					app.IsRunning(),
+				),
+			}
+
+			smokeTestReporter.RegisterSpecSteps(specSteps)
+
+			if skip {
+				serviceCreateStep.Result = "SKIPPED"
+			} else {
+				performSteps(specSteps)
+			}
+
+		})
+
+		AfterEach(func() {
+			specSteps := []*reporter.Step{
+				reporter.NewStep(
+					fmt.Sprintf("Unbind the %q plan instance", planName),
+					testCF.UnbindService(appName, serviceInstanceName),
+				),
+				reporter.NewStep(
+					fmt.Sprintf("Delete security group '%s'", securityGroupName),
+					testCF.DeleteSecurityGroup(securityGroupName),
+				),
+				reporter.NewStep(
+					fmt.Sprintf("Delete the service key %s for the %q plan instance", serviceKeyName, planName),
+					testCF.DeleteServiceKey(serviceInstanceName, serviceKeyName),
+				),
+				reporter.NewStep(
+					fmt.Sprintf("Delete the %q plan instance", planName),
+					testCF.DeleteService(serviceInstanceName),
+				),
+				reporter.NewStep(
+					fmt.Sprintf("Ensure service instance for plan %q has been deleted", planName),
+					testCF.EnsureServiceInstanceGone(serviceInstanceName),
+				),
+				reporter.NewStep(
+					"Delete the app",
+					testCF.Delete(appName),
+				),
+			}
+
+			smokeTestReporter.RegisterSpecSteps(specSteps)
+			performSteps(specSteps)
+		})
+
+		Context("on-demand-cache", func() {
+			for _, currentPlan := range redisConfig.Plans {
+				if !currentPlan.HAEnabled {
+					continue
+				}
+
+				planName = currentPlan.Name
+
+				It("should successfully perform failover", func() {
+					uri := fmt.Sprintf("https://%s.%s", appName, redisConfig.Config.AppsDomain)
+
+					if redisConfig.UseHttpApp {
+						uri = fmt.Sprintf("http://%s.%s", appName, redisConfig.Config.AppsDomain)
+					}
+
+					app := redis.NewApp(uri, testCF.ShortTimeout, retryInterval)
+
+					if !skip {
+						standardPortSpecs := []*reporter.Step{
+							reporter.NewStep(
+								"Write a key/value pair to Redis",
+								app.Write("mykey", "myvalue"),
+							),
+							reporter.NewStep(
+								"Read the key/value pair back",
+								app.ReadAssert("mykey", "myvalue"),
+							),
+						}
+						smokeTestReporter.RegisterSpecSteps(standardPortSpecs)
+						performSteps(standardPortSpecs)
+
+						master := basicMasterValidations(app)
+						replicas := basicReplicasValidation(app)
+
+						performFailOver(app)
+
+						newMaster := basicMasterValidations(app)
+						newReplicas := basicReplicasValidation(app)
+
+						performCrossValidation(master, newMaster, replicas, newReplicas)
+
+						smokeTestReporter.RegisterSpecSteps(standardPortSpecs)
+						performSteps(standardPortSpecs)
+					}
+				})
+			}
+		})
+	})
+})
+
+func basicMasterValidations(app *redis.App) utils.RedisMasterInfo {
+	master, err := utils.NewRedisMasterInfo(app.Read("master"))
+	Expect(err).To(BeNil())
+
+	Expect(master.Name).To(Equal("redis-master"))
+	Expect(master.RoleReported).To(Equal("master"))
+	Expect(master.NumOtherSentinels).To(Equal("2"))
+	Expect(master.NumSlaves).To(Equal("2"))
+	Expect(master.Quorum).To(Equal("2"))
+
+	return master
+}
+
+func basicReplicasValidation(app *redis.App) []utils.RedisReplicaInfo {
+	replicas, err := utils.NewRedisReplicaInfo(app.Read("replicas"))
+	Expect(err).To(BeNil())
+
+	Expect(replicas).To(HaveLen(2))
+	for _, replica := range replicas {
+		Expect(replica.MasterLinkStatus).To(Equal("ok"), fmt.Sprintf("replica %s's link to master is not 'ok'", replica.Name))
+	}
+
+	return replicas
+}
+
+func performFailOver(app *redis.App) {
+	failoverSpecs := []*reporter.Step{
+		reporter.NewStep(
+			"Perform manual failover",
+			app.ReadAssert("failover", "OK"),
+		),
+		reporter.NewStep(
+			"Wait 20 seconds before failover completes",
+			func() {
+				time.Sleep(20 * time.Second)
+			},
+		),
+	}
+
+	smokeTestReporter.RegisterSpecSteps(failoverSpecs)
+	performSteps(failoverSpecs)
+}
+
+func performCrossValidation(master, newMaster utils.RedisMasterInfo, replicas, newReplicas []utils.RedisReplicaInfo) {
+	//Check if new master and old master is not the same
+	Expect(newMaster.Ip).NotTo(Equal(master.Ip))
+	Expect(newMaster.Runid).NotTo(Equal(master.Runid))
+
+	//Check if new master is one of the old replica
+	index := utils.GetIndexOfInstanceMatchingIpAndRunId(replicas, newMaster.Ip, newMaster.Runid)
+	Expect(index).NotTo(Equal(-1))
+
+	oldReplica := replicas[index]
+	Expect(newMaster.Ip).To(Equal(oldReplica.Ip))
+	Expect(newMaster.Port).To(Equal(oldReplica.Port))
+	Expect(newMaster.Runid).To(Equal(oldReplica.Runid))
+
+	//Check if odl master has joined as replica
+	index = utils.GetIndexOfInstanceMatchingIpAndRunId(newReplicas, master.Ip, master.Runid)
+	Expect(index).NotTo(Equal(-1))
+
+	oldMaster := newReplicas[index]
+	Expect(oldMaster.Ip).To(Equal(master.Ip))
+	Expect(oldMaster.Port).To(Equal(master.Port))
+	Expect(oldMaster.Runid).To(Equal(master.Runid))
+}

--- a/service/service_suite_test.go
+++ b/service/service_suite_test.go
@@ -41,6 +41,11 @@ func (rc retryConfig) MaxRetries() int {
 	return int(rc.Attempts)
 }
 
+type plan struct {
+	Name      string `json:"name"`
+	HAEnabled bool   `json:"ha"`
+}
+
 type redisTestConfig struct {
 	config.Config
 
@@ -50,6 +55,7 @@ type redisTestConfig struct {
 	TLSEnabled  bool        `json:"tls_enabled"`
 	TLSVersions []string    `json:"tls_versions"`
 	UseHttpApp  bool        `json:"use_http_app_smoke_tests"`
+	Plans       []plan      `json:"plans"`
 }
 
 func loadRedisTestConfig(path string) redisTestConfig {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -145,7 +145,8 @@ var _ = Describe("Redis On-Demand", func() {
 
 	Context("service instance", func() {
 		Context("life-cycle", func() {
-			for _, planName = range redisConfig.PlanNames {
+			for _, currentPlan := range redisConfig.Plans {
+				planName = currentPlan.Name
 				Context("for "+strings.ToUpper(planName)+" plans:", func() {
 					AssertLifeCycleBehavior(planName)
 				})

--- a/service/utils/ha.go
+++ b/service/utils/ha.go
@@ -1,0 +1,56 @@
+package utils
+
+import "encoding/json"
+
+type RedisMasterInfo struct {
+	Name              string `json:"name"`
+	Ip                string `json:"ip"`
+	Port              string `json:"port"`
+	Runid             string `json:"runid"`
+	RoleReported      string `json:"role-reported"`
+	NumSlaves         string `json:"num-slaves"`
+	NumOtherSentinels string `json:"num-other-sentinels"`
+	Quorum            string `json:"quorum"`
+}
+
+type RedisReplicaInfo struct {
+	Name             string `json:"name"`
+	Ip               string `json:"ip"`
+	Port             string `json:"port"`
+	Runid            string `json:"runid"`
+	RoleReported     string `json:"role-reported"`
+	MasterHost       string `json:"master-host"`
+	MasterPort       string `json:"master-port"`
+	MasterLinkStatus string `json:"master-link-status"`
+}
+
+func NewRedisMasterInfo(b []byte) (RedisMasterInfo, error) {
+	var redisMasterInfo RedisMasterInfo
+	err := json.Unmarshal(b, &redisMasterInfo)
+	if err != nil {
+		return redisMasterInfo, err
+	}
+
+	return redisMasterInfo, nil
+}
+
+func NewRedisReplicaInfo(b []byte) ([]RedisReplicaInfo, error) {
+	var redisReplicaInfo []RedisReplicaInfo
+	err := json.Unmarshal(b, &redisReplicaInfo)
+	if err != nil {
+		return redisReplicaInfo, err
+	}
+
+	return redisReplicaInfo, nil
+}
+
+func GetIndexOfInstanceMatchingIpAndRunId(replicas []RedisReplicaInfo, ip, runId string) int {
+	index := -1
+	for i, instance := range replicas {
+		if instance.Ip == ip && instance.Runid == runId {
+			index = i
+		}
+	}
+
+	return index
+}


### PR DESCRIPTION
- Adds Smoke tests for HA
- Only runs HA test cases for the plan which has HA enabled
- Reverted back the ginkgo changes as the change was too big and needs proper time and testing 

TODOs:
- [x] create story to review the current configuration of smoke-tests. smoke-tests should not run for every plan. it'll count towards resource usage on our ci/shepherd cloud envs and customer envs too. (created JIRA [REDVM-464](https://jira-pivotal.atlassian.net/browse/REDVM-464))

- [x] Tests does not include migration tests. Needs to be included in a separate story. Also, check BBR support for HA mode in the same story (added details in [REDVM-437](https://jira-pivotal.atlassian.net/browse/REDVM-437))

- [x] In ha tests, we separately do not check for eventual consistency as after failover, we're trying to read from the same key which should be present in new master. Which ensures the consistency. Do we want to add a tests with insertion and replication of large volume for checking consistency with large volume? @pnikonowicz, @ashrivastav13, @JulianBenitez99 please review this section


[REDVM-464]: https://jira-pivotal.atlassian.net/browse/REDVM-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[REDVM-437]: https://jira-pivotal.atlassian.net/browse/REDVM-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ